### PR TITLE
Add clinical safety case report export

### DIFF
--- a/src/lib/components/LinkImpactModal.svelte
+++ b/src/lib/components/LinkImpactModal.svelte
@@ -2,7 +2,14 @@
 <script lang="ts">
   import { createEventDispatcher } from 'svelte';
   export let show = false;
-  export let impacts = [];
+  type ImpactItem = {
+    id: string;
+    description: string;
+    likelihood?: string;
+    severity?: string;
+  };
+
+  export let impacts: ImpactItem[] = [];
   export let search = '';
   const dispatch = createEventDispatcher();
 
@@ -24,7 +31,7 @@
       <div class="modal-content">
         <div class="modal-header">
           <h5 class="modal-title">Link Existing Impact</h5>
-          <button type="button" class="btn-close" on:click={handleClose}></button>
+          <button type="button" class="btn-close" aria-label="Close" on:click={handleClose}></button>
         </div>
         <div class="modal-body">
           <input

--- a/src/lib/stores/project.js
+++ b/src/lib/stores/project.js
@@ -20,6 +20,14 @@ export const project = persistedCookie('hazardwise-project', {
   title: '',
   description: '',
   safetyOfficer: '',
+  alternatives: '',
+  reportSections: {
+    introduction: '',
+    purpose: '',
+    governance: '',
+    riskOverview: '',
+    conclusion: ''
+  },
   hazards: [
     // example hazard:
     // {

--- a/src/routes/workspace/+page.svelte
+++ b/src/routes/workspace/+page.svelte
@@ -9,6 +9,8 @@
   $: {
     const p = $project;
     const m = $mitigations;
+    const sections = p.reportSections ?? {};
+    const narrativeProvided = Object.values(sections).some(value => (value ?? '').toString().trim().length > 0);
     console.log('mitigations', m);
     const hazardCount = p.hazards?.length ?? 0;
 
@@ -18,7 +20,8 @@
       hazardLogRiskAssessment: String(hazardCount)+" Hazards Identified",
       mitigationsInPlace: String(m.length)+" Mitigations Identified",
       vendorComplianceReview: Boolean(p.compliance?.vendorComplianceReviewed),
-      alternativeOptionsAnalysis: Boolean(p.alternatives?.trim())
+      alternativeOptionsAnalysis: Boolean(p.alternatives?.trim()),
+      clinicalSafetyNarrative: narrativeProvided
     };
   }
 
@@ -63,6 +66,13 @@
       title: 'Consideration of Risks/Benefits of Alternative Options',
       description:
         'Evaluation of potential alternatives, including risk-benefit analysis to justify selected solutions.',
+      link: base + '/workspace/project'
+    },
+    {
+      key: 'clinicalSafetyNarrative',
+      title: 'Clinical Safety Case Narrative Prepared',
+      description:
+        'Draft the introduction, governance, risk summary, and conclusion text that will appear in the exported safety case report.',
       link: base + '/workspace/project'
     }
   ];

--- a/src/routes/workspace/export/+page.svelte
+++ b/src/routes/workspace/export/+page.svelte
@@ -1,16 +1,25 @@
 <!-- hazardwise/src/routes/workspace/export/+page.svelte -->
 <script lang="ts">
-  // Placeholder logic can go here in the future
-import ExportData from "$lib/components/ExportData.svelte";
-import { base } from "$app/paths";
+  import ExportData from '$lib/components/ExportData.svelte';
+  import { base } from '$app/paths';
 </script>
 
 <main class="container py-4">
   <h1 class="mb-4">Export tools</h1>
-  <ExportData /> 
-  <a class="btn btn-outline-secondary mt-3" href="{base}/printableExport" target="_blank">
-    Printable Export
-  </a>
-  <!-- You can add search, filters, tables, and forms here -->
+  <ExportData />
+
+  <div class="d-flex flex-column flex-md-row gap-2 mt-3">
+    <a class="btn btn-outline-secondary" href={base + '/printableExport'} target="_blank" rel="noopener">
+      Printable Hazard Summary
+    </a>
+    <a
+      class="btn btn-primary"
+      href={base + '/workspace/export/clinical-report'}
+      target="_blank"
+      rel="noopener"
+    >
+      Clinical Safety Case Report
+    </a>
+  </div>
 </main>
  

--- a/src/routes/workspace/export/clinical-report/+page.svelte
+++ b/src/routes/workspace/export/clinical-report/+page.svelte
@@ -1,0 +1,288 @@
+<script lang="ts">
+  import { browser } from '$app/environment';
+  import { project } from '$lib/stores/project.js';
+  import { causes } from '$lib/stores/causes.js';
+  import { impacts } from '$lib/stores/impacts.js';
+  import { mitigations } from '$lib/stores/mitigations.js';
+  import { HazardUtils } from '$lib/utils/hazard';
+  import { assessHazardImpact } from '$lib/utils/dcbRisk';
+
+  const generatedOn = new Date().toLocaleDateString();
+
+  const defaultTexts = {
+    introduction:
+      'DCB0160 is a clinical risk management standard that health and social care organisations must comply with to safely implement health IT systems. This clinical safety case report summarises the assurance work completed for this project.',
+    purpose:
+      "This report documents clinical hazards and risks, and captures the mitigations required to maintain clinical safety. It supports governance teams in confirming that the solution is safe to deploy.",
+    governance: ({ safetyOfficer }: { safetyOfficer: string }) =>
+      `A Clinical Safety Officer (CSO) – ${safetyOfficer || 'name to be confirmed'} – is accountable for the ongoing clinical safety of the system, including maintaining the hazard log, monitoring mitigations and advising senior leadership. Final deployment decisions rest with the organisation's accountable officers informed by the CSO's recommendation.`,
+    riskOverview:
+      'Each hazard has been assessed for potential harm severity and likelihood. Residual risk is evaluated after applying mitigations to ensure that risks are reduced to an acceptable level wherever possible.',
+    conclusion: ({ projectTitle }: { projectTitle: string }) =>
+      `Subject to the mitigations described within this report remaining effective, the risk profile for ${projectTitle || 'this system'} is considered acceptable for clinical use. Leadership should ensure ongoing monitoring and review in line with governance arrangements.`
+  } as const;
+
+  $: projectTitle = $project.title || 'Untitled Project';
+  $: projectDescription = $project.description || 'No description provided yet.';
+  $: safetyOfficer = $project.safetyOfficer || '';
+  $: alternatives = $project.alternatives?.trim() || '';
+  $: reportSections = $project.reportSections ?? {};
+  $: hazards = $project.hazards || [];
+
+  type SectionKey = keyof typeof defaultTexts;
+
+  function resolveSection(key: SectionKey) {
+    const value = (reportSections as Record<string, string> | undefined)?.[key];
+    const text = typeof value === 'string' ? value.trim() : '';
+    if (text) return text;
+    const fallback = defaultTexts[key];
+    if (typeof fallback === 'function') {
+      return fallback({ safetyOfficer, projectTitle });
+    }
+    return fallback;
+  }
+
+  function getCauses(hazard: any) {
+    return (hazard.causeIds || [])
+      .map((cid: string) => $causes.find((c) => c.id === cid))
+      .filter(Boolean);
+  }
+
+  function getAllMitigations(hazard: any) {
+    const hazardMits = (hazard.mitigationIds || [])
+      .map((mid: string) => $mitigations.find((m) => m.id === mid))
+      .filter(Boolean);
+
+    const causeMits = (hazard.causeIds || [])
+      .flatMap((cid: string) => $causes.find((c) => c.id === cid)?.mitigationIds || [])
+      .map((mid: string) => $mitigations.find((m) => m.id === mid))
+      .filter(Boolean);
+
+    const map = new Map();
+    [...hazardMits, ...causeMits].forEach((mit: any) => {
+      if (mit) map.set(mit.id, mit);
+    });
+    return Array.from(map.values());
+  }
+
+  function getFullImpacts(hazard: any) {
+    return (hazard.hazardImpacts || [])
+      .map((hi: any) => {
+        const core = $impacts.find((i) => i.id === hi.impactID);
+        if (!core) return null;
+        const risk = assessHazardImpact(hi);
+        return { hi, core, risk };
+      })
+      .filter(Boolean);
+  }
+
+  function residualRiskLabel(hazard: any) {
+    const highest = HazardUtils.getHighestRisk(hazard);
+    return highest.rating || 'Not yet assessed';
+  }
+
+  function downloadDoc() {
+    if (!browser) return;
+    const container = document.getElementById('report-content');
+    if (!container) return;
+    const html = `<!DOCTYPE html><html><head><meta charset="utf-8"><title>${projectTitle} Clinical Safety Case Report</title></head><body>${container.innerHTML}</body></html>`;
+    const blob = new Blob([html], { type: 'application/msword' });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = `${projectTitle.replace(/\s+/g, '-').toLowerCase() || 'clinical-safety-report'}.doc`;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
+  }
+</script>
+
+<svelte:head>
+  <title>Clinical Safety Case Report – {projectTitle}</title>
+</svelte:head>
+
+<style>
+  :global(body) {
+    background-color: #f8f9fa;
+  }
+  main {
+    font-family: 'Segoe UI', Tahoma, sans-serif;
+    color: #212529;
+  }
+  #report-content {
+    background: #ffffff;
+    padding: 2rem;
+    border-radius: 0.5rem;
+    border: 1px solid #dee2e6;
+  }
+  h1, h2, h3 {
+    font-weight: 600;
+  }
+  .section-heading {
+    margin-top: 2rem;
+    border-bottom: 2px solid #0d6efd;
+    padding-bottom: 0.5rem;
+  }
+  table {
+    width: 100%;
+    border-collapse: collapse;
+    margin-top: 1rem;
+  }
+  table, th, td {
+    border: 1px solid #adb5bd;
+  }
+  th, td {
+    padding: 0.75rem;
+    text-align: left;
+    vertical-align: top;
+  }
+  .muted {
+    color: #6c757d;
+  }
+  .download-toolbar {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 1.5rem;
+  }
+  .small-label {
+    font-size: 0.9rem;
+    color: #495057;
+  }
+</style>
+
+<main class="container py-4">
+  <div class="download-toolbar">
+    <div>
+      <h1 class="mb-1">Clinical Safety Case Report</h1>
+      <div class="small-label">Project: <strong>{projectTitle}</strong></div>
+      <div class="small-label">Generated: {generatedOn}</div>
+    </div>
+    <button class="btn btn-primary" on:click={downloadDoc}>Download Word (.doc)</button>
+  </div>
+
+  <div id="report-content">
+    <section>
+      <h2 class="section-heading">1. Introduction</h2>
+      <p>{resolveSection('introduction')}</p>
+    </section>
+
+    <section>
+      <h2 class="section-heading">2. Purpose</h2>
+      <p>{resolveSection('purpose')}</p>
+    </section>
+
+    <section>
+      <h2 class="section-heading">3. Description of the Proposed System</h2>
+      <p>{projectDescription}</p>
+    </section>
+
+    <section>
+      <h2 class="section-heading">4. Clinical Safety Governance</h2>
+      <p>{resolveSection('governance')}</p>
+      <p>
+        <strong>Named Clinical Safety Officer:</strong>
+        {safetyOfficer ? safetyOfficer : 'To be confirmed'}
+      </p>
+    </section>
+
+    <section>
+      <h2 class="section-heading">5. Hazard Identification</h2>
+      {#if hazards.length}
+        <p>The following hazards have been identified through multidisciplinary workshops and review:</p>
+        <table>
+          <thead>
+            <tr>
+              <th scope="col">Hazard ID</th>
+              <th scope="col">Description</th>
+              <th scope="col">Residual Risk Level</th>
+            </tr>
+          </thead>
+          <tbody>
+            {#each hazards as hazard}
+              <tr>
+                <td>{hazard.id}</td>
+                <td>{hazard.description || 'Description not provided'}</td>
+                <td>{residualRiskLabel(hazard)}</td>
+              </tr>
+            {/each}
+          </tbody>
+        </table>
+      {:else}
+        <p class="muted">No hazards have been logged yet.</p>
+      {/if}
+    </section>
+
+    <section>
+      <h2 class="section-heading">6. Risk Assessment &amp; Mitigations</h2>
+      <p>{resolveSection('riskOverview')}</p>
+      {#if hazards.length}
+        {#each hazards as hazard}
+          <div class="mb-4">
+            <h3>{hazard.id}: {hazard.description || 'Description not provided'}</h3>
+            <p><strong>Residual Risk:</strong> {residualRiskLabel(hazard)}</p>
+
+            <h4>Causes</h4>
+            {#if getCauses(hazard).length}
+              <ul>
+                {#each getCauses(hazard) as cause}
+                  <li>{cause.description}</li>
+                {/each}
+              </ul>
+            {:else}
+              <p class="muted">No causes recorded.</p>
+            {/if}
+
+            <h4>Mitigations</h4>
+            {#if getAllMitigations(hazard).length}
+              <ul>
+                {#each getAllMitigations(hazard) as mitigation}
+                  <li>{mitigation.description}</li>
+                {/each}
+              </ul>
+            {:else}
+              <p class="muted">No mitigations recorded.</p>
+            {/if}
+
+            <h4>Impact Assessment</h4>
+            {#if getFullImpacts(hazard).length}
+              <table>
+                <thead>
+                  <tr>
+                    <th scope="col">Impact</th>
+                    <th scope="col">Severity</th>
+                    <th scope="col">Likelihood</th>
+                    <th scope="col">Residual Risk</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {#each getFullImpacts(hazard) as { hi, core, risk }}
+                    <tr>
+                      <td>{core.description}</td>
+                      <td>{core.severity || 'Not set'}</td>
+                      <td>{hi.likelihood || 'Not set'}</td>
+                      <td>{risk.rating || 'Not assessed'}</td>
+                    </tr>
+                  {/each}
+                </tbody>
+              </table>
+            {:else}
+              <p class="muted">No impact assessments recorded.</p>
+            {/if}
+          </div>
+        {/each}
+      {/if}
+    </section>
+
+    <section>
+      <h2 class="section-heading">7. Alternative Options</h2>
+      <p>{alternatives || 'Alternative approaches have not been documented yet.'}</p>
+    </section>
+
+    <section>
+      <h2 class="section-heading">8. Clinical Safety Case Report Conclusion</h2>
+      <p>{resolveSection('conclusion')}</p>
+    </section>
+  </div>
+</main>

--- a/src/routes/workspace/mitigations/+page.svelte
+++ b/src/routes/workspace/mitigations/+page.svelte
@@ -1,26 +1,25 @@
 <!-- src/routes/mitigations/+page.svelte -->
-<script>
+<script lang="ts">
   import { mitigations } from '$lib/stores/mitigations.js';
-  import { base } from '$app/paths';
   import EditMitigationModal from '$lib/components/EditMitigationModal.svelte';
-  /** 
-   * Prompt the user and remove a mitigation by id 
+  /**
+   * Prompt the user and remove a mitigation by id
    */
-  function removeMitigation(id) {
+  function removeMitigation(id: string) {
     if (confirm('Are you sure you want to remove this mitigation?')) {
       mitigations.update(list => list.filter(item => item.id !== id));
     }
   }
 
   let showModal = false;
-  let selectedId = null;
+  let selectedId: string | null = null;
 
-  function openEditor(id) {
+  function openEditor(id: string) {
     selectedId = id;
     showModal = true;
   }
 
-  function handleSave(event) {
+  function handleSave() {
     // your modal already updated the store
     showModal = false;
   }
@@ -30,7 +29,7 @@
   }
 
   // Toggle “implemented” on/off
-  function toggleImplemented(id, isImplemented) {
+  function toggleImplemented(id: string, isImplemented: boolean) {
     mitigations.update(list =>
       list.map(item =>
         item.id === id ? { ...item, implemented: isImplemented } : item
@@ -60,7 +59,9 @@
             <input
               type="checkbox"
               checked={m.implemented}
-              on:change={e => toggleImplemented(m.id, e.target.checked)}
+              on:change={event =>
+                toggleImplemented(m.id, (event.currentTarget as HTMLInputElement).checked)
+              }
               aria-label="Mark {m.id} implemented"
             />
           </td>
@@ -87,7 +88,7 @@
 
 {#if showModal}
   <EditMitigationModal
-    mitigationID={selectedId}
+    mitigationID={selectedId ?? ''}
     on:save={handleSave}
     on:cancel={handleCancel}
   />

--- a/src/routes/workspace/project/+page.svelte
+++ b/src/routes/workspace/project/+page.svelte
@@ -8,6 +8,11 @@ import { goto } from '$app/navigation';
   let description: string = '';
   let safetyOfficer: string = '';
   let alternatives: string = '';
+  let introduction: string = '';
+  let purpose: string = '';
+  let governance: string = '';
+  let riskOverview: string = '';
+  let conclusion: string = '';
 
   // Subscribe to project store
   const unsubscribe = project.subscribe(p => {
@@ -16,6 +21,13 @@ import { goto } from '$app/navigation';
     safetyOfficer = p.safetyOfficer;
     // Add an "alternatives" field if not present
     alternatives = (p as any).alternatives ?? '';
+
+    const sections = (p as any).reportSections ?? {};
+    introduction = sections.introduction ?? '';
+    purpose = sections.purpose ?? '';
+    governance = sections.governance ?? '';
+    riskOverview = sections.riskOverview ?? '';
+    conclusion = sections.conclusion ?? '';
   });
   onDestroy(unsubscribe);
 
@@ -27,7 +39,15 @@ import { goto } from '$app/navigation';
       description,
       safetyOfficer,
       // persist alternatives field
-      alternatives
+      alternatives,
+      reportSections: {
+        ...((p as any).reportSections ?? {}),
+        introduction,
+        purpose,
+        governance,
+        riskOverview,
+        conclusion
+      }
     }));
     goto(base + '/workspace');
   }
@@ -61,6 +81,31 @@ import { goto } from '$app/navigation';
     </div>
 
     <div class="mb-3">
+      <label for="reportIntroduction" class="form-label">Clinical Safety Report Introduction</label>
+      <textarea
+        id="reportIntroduction"
+        class="form-control"
+        rows="4"
+        bind:value={introduction}
+        placeholder="Set out the DCB0160 context and provide any local introductory wording"
+      ></textarea>
+      <div class="form-text">
+        This text appears in the report's opening section. Leave blank to use the default wording provided in the export.
+      </div>
+    </div>
+
+    <div class="mb-3">
+      <label for="reportPurpose" class="form-label">Purpose of this Safety Case</label>
+      <textarea
+        id="reportPurpose"
+        class="form-control"
+        rows="3"
+        bind:value={purpose}
+        placeholder="Explain the objectives of the clinical safety case report"
+      ></textarea>
+    </div>
+
+    <div class="mb-3">
       <label for="safetyOfficer" class="form-label">Safety Officer</label>
       <input
         type="text"
@@ -72,6 +117,17 @@ import { goto } from '$app/navigation';
     </div>
 
     <div class="mb-3">
+      <label for="reportGovernance" class="form-label">Clinical Safety Governance Notes</label>
+      <textarea
+        id="reportGovernance"
+        class="form-control"
+        rows="3"
+        bind:value={governance}
+        placeholder="Outline governance arrangements, decision makers, or review cadence"
+      ></textarea>
+    </div>
+
+    <div class="mb-3">
       <label for="alternatives" class="form-label">Alternatives</label>
       <textarea
         id="alternatives"
@@ -79,6 +135,28 @@ import { goto } from '$app/navigation';
         rows="4"
         bind:value={alternatives}
         placeholder="Outline any alternative approaches or tools considered"
+      ></textarea>
+    </div>
+
+    <div class="mb-3">
+      <label for="reportRiskOverview" class="form-label">Risk Assessment Summary</label>
+      <textarea
+        id="reportRiskOverview"
+        class="form-control"
+        rows="4"
+        bind:value={riskOverview}
+        placeholder="Highlight key risks, mitigations, or sign-offs that leadership should note"
+      ></textarea>
+    </div>
+
+    <div class="mb-4">
+      <label for="reportConclusion" class="form-label">Conclusion</label>
+      <textarea
+        id="reportConclusion"
+        class="form-control"
+        rows="3"
+        bind:value={conclusion}
+        placeholder="Record the overall safety conclusion and any conditions"
       ></textarea>
     </div>
 


### PR DESCRIPTION
## Summary
- capture narrative fields for the clinical safety report within the project workspace and surface their completion status
- add a dedicated clinical safety case report export with Word-friendly formatting and download support
- tidy supporting components by updating export navigation and strengthening type safety in mitigation management dialogs

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68de5367a3d88328bc5fbbbf4ec369d5